### PR TITLE
Milestone1 abstract base classes

### DIFF
--- a/timeseries/arraytimeseries.py
+++ b/timeseries/arraytimeseries.py
@@ -1,8 +1,7 @@
-from timeseries import TimeSeries
+from sizedcontainertimeseriesinterface import SizedContainerTimeSeriesInterface
 import numpy as np
 
-
-class ArrayTimeSeries(TimeSeries):
+class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
     """
     A subclass that stores two arrays internally, an ordered set
     of numerical data and its time points contiguously as two of `np.array`.
@@ -32,14 +31,34 @@ class ArrayTimeSeries(TimeSeries):
         for val in zip(self._times, self._values):
             yield val
 
-    def __itertimes__(self):
-        super().__itertimes__()
 
-    def __iteritems__(self):
-        super().__iteritems__()
+    # J: since our ABC is an interface, need to
+    # reimplement these here... IMO we should
+    # consider changing these so that our ABC
+    # implements the most essential functionality
+    # instead of just being an interface. this is not java :)
+
+    # J: should this not iterate over tuples?
+    def __iter__(self):
+        for val in self._values:
+            yield val
+
+    def itertimes(self):
+        for tim in self._times:
+            yield tim
+
+    def itervalues(self):
+        # R: Identical to __iter__
+        for val in self._values:
+            yield val
+
+    def iteritems(self):
+        for i in range(len(self._values)):
+            yield self._times[i], self._values[i]
 
     def __len__(self):
-        #super().__len__() Note: len of np.appry returns and error for arrays of size 1.
+        # Note: len of np.appry returns and error for arrays of size 1.
+        #super().__len__()
         return len(np.atleast_1d(self._values))
 
     def __getitem__(self, index):

--- a/timeseries/arraytimeseries.py
+++ b/timeseries/arraytimeseries.py
@@ -27,8 +27,8 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
         # we don't inherit from TimeSeries anymore and
         # since the upper levels of the inheritance hierarchy
         # are (mostly) abstract things...
-        self.is_sequence(times)
-        self.is_sequence(values)
+        self.__class__.is_sequence(times)
+        self.__class__.is_sequence(values)
         self._times = np.array(list(times))
         self._values = np.array(list(values))
 
@@ -37,57 +37,14 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
 
         if len(self._times) != len(set(self._times)):
             raise ValueError("Time data should contain no repeats")
-
-    def __iter__(self):
-        for val in zip(self._times, self._values):
-            yield val
-
-
-    # J: since our ABC is an interface, need to
-    # reimplement these here... IMO we should
-    # consider changing these so that our ABC
-    # implements the most essential functionality
-    # instead of just being an interface. this is not java :)
-
-    # J: should this not iterate over tuples?
-    def __iter__(self):
-        for val in self._values:
-            yield val
-
-    def itertimes(self):
-        for tim in self._times:
-            yield tim
-
-    def itervalues(self):
-        # R: Identical to __iter__
-        for val in self._values:
-            yield val
-
-    def iteritems(self):
-        for i in range(len(self._values)):
-            yield self._times[i], self._values[i]
-
+    
     def __len__(self):
         # Note: len of np.appry returns and error for arrays of size 1.
         #super().__len__()
         return len(np.atleast_1d(self._values))
 
-    def __getitem__(self, index):
-        try:
-            return self._times[index], self._values[index]
-        except IndexError:
-            raise IndexError("Index out of bounds!")
 
-    def __setitem__(self, index, item):
-        try:
-            self._times[index] = item[0]
-            self._values[index] = item[1]
-        except IndexError:
-            raise IndexError("Index out of bounds!")
-
-    def _check_time_domains_helper(lhs , rhs):
-        if not np.array_equal(lhs._times,rhs._times):
-            raise ValueError(str(lhs)+' and '+str(rhs)+' must have identical time domains')
+    #### ABSTRACT FNS BELOW; REMOVE THIS LATER ######
 
     def __eq__(self, rhs):
         # Note: np.array_equal compares both elements and dimensions.
@@ -98,8 +55,6 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
         except TypeError:
             raise NotImplemented
 
-
-    # J: adding this here to make test pass
     # imo we should consider implementing this in
     # SizedContainerTimeSeriesInterface...
     def interpolate(self,ts_to_interpolate):
@@ -152,13 +107,7 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
         return self.__class__(values=interpolated_ts,times=ts_to_interpolate)
 
     # J: these methods need to be implemented
-    def __abs__(self):
-        pass
     def __add__ (self):
-        pass
-    def __bool__(self):
-        pass
-    def __contains__(self):
         pass
     def __mul__(self):
         pass
@@ -170,13 +119,9 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
         pass
     def __radd__(self):
         pass
-    def __repr__(self):
-        pass
     def __rmul__(self):
         pass
     def __rsub__(self):
-        pass
-    def __str__(self):
         pass
     def __sub__(self):
         pass

--- a/timeseries/arraytimeseries.py
+++ b/timeseries/arraytimeseries.py
@@ -23,9 +23,20 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
 
     """
     def __init__(self, times, values):
-        TimeSeries.__init__(self, times, values)
-        self._times = np.array(times)
-        self._values = np.array(values)
+        # J: breaking DRY and adding sequenceness checks here, since
+        # we don't inherit from TimeSeries anymore and
+        # since the upper levels of the inheritance hierarchy
+        # are (mostly) abstract things...
+        self.is_sequence(times)
+        self.is_sequence(values)
+        self._times = np.array(list(times))
+        self._values = np.array(list(values))
+
+        if len(self._times) != len(self._values):
+            raise ValueError("Time and input data of incompatible dimensions")
+
+        if len(self._times) != len(set(self._times)):
+            raise ValueError("Time data should contain no repeats")
 
     def __iter__(self):
         for val in zip(self._times, self._values):
@@ -86,3 +97,86 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
 
         except TypeError:
             raise NotImplemented
+
+
+    # J: adding this here to make test pass
+    # imo we should consider implementing this in
+    # SizedContainerTimeSeriesInterface...
+    def interpolate(self,ts_to_interpolate):
+        """
+        Returns new TimeSeries instance with piecewise-linear-interpolated values
+        for submitted time-times.If called times are outside of the domain of the existing
+        Time Series, the minimum or maximum values are returned.
+
+        Parameters
+        ----------
+        self: TimeSeries instance
+        ts_to_interpolate: list or other sequence of times to be interpolated
+
+        """
+        def binary_search(times, t):
+            """ Returns surrounding time indexes for value that is to be interpolated"""
+            min = 0
+            max = len(times) - 1
+            while True:
+                if max < min:
+                    return (max,min)
+                m = (min + max) // 2
+                if times[m] < t:
+                    min = m + 1
+                elif times[m] > t:
+                    max = m - 1
+                else: #Should never hit this case in current implementation
+                    return (min,max)
+
+        def interpolate_val(times,values,t):
+            """Returns interpolated value for given time"""
+
+            if t in times:          #time already exits in ts -- return it
+                return values[times.index(t)]
+
+            elif t >= times[-1]:    #time is above the domain of the existing values -- return max time value
+                return values[-1]
+
+            elif t <= times[0]:     #time is below the domain of the existing values -- return min time value
+                return values[0]
+
+            else:                   #time is between two existing points -- interpolate it
+                low,high = binary_search(times, t)
+                slope = (float(values[high]) - values[low])/(times[high] - times[low])
+                c = values[low]
+                interpolated_val = (t-times[low])*slope + c
+                return interpolated_val
+
+        interpolated_ts = [interpolate_val(self._times,self._values,t) for t in ts_to_interpolate]
+        return self.__class__(values=interpolated_ts,times=ts_to_interpolate)
+
+    # J: these methods need to be implemented
+    def __abs__(self):
+        pass
+    def __add__ (self):
+        pass
+    def __bool__(self):
+        pass
+    def __contains__(self):
+        pass
+    def __mul__(self):
+        pass
+    def __ne__(self):
+        pass
+    def __neg__(self):
+        pass
+    def __pos__(self):
+        pass
+    def __radd__(self):
+        pass
+    def __repr__(self):
+        pass
+    def __rmul__(self):
+        pass
+    def __rsub__(self):
+        pass
+    def __str__(self):
+        pass
+    def __sub__(self):
+        pass

--- a/timeseries/simulatedtimeseries.py
+++ b/timeseries/simulatedtimeseries.py
@@ -42,3 +42,5 @@ class SimulatedTimeSeries(StreamTimeSeriesInterface):
 		except StopIteration:
 			# not sure what the optimal error type is here
 			raise IndexError("Make sure you don't produce more values than the generator has!")
+
+		return produced

--- a/timeseries/simulatedtimeseries.py
+++ b/timeseries/simulatedtimeseries.py
@@ -1,0 +1,44 @@
+from streamtimeseriesinterface import StreamTimeSeriesInterface
+
+class SimulatedTimeSeries(StreamTimeSeriesInterface):
+	"""
+	Description
+	-----------
+	Implements a Time Series without a fixed storage.
+	Uses generators to produce a streaming effect.
+
+	Parameters
+	----------
+	times_gen: generator
+		lazily evaluated generator representing time values
+	values: generator
+		lazily evaluated generator representing data values
+	"""
+	def __init__(self, times_gen, values_gen):
+		super(SimulatedTimeSeries, self).__init__()
+		self.times = times_gen
+		self.values = values_gen
+
+	def produce(self, chunk):
+		"""
+		Description
+		-----------
+		Produces `chunk` new values of the time series
+
+		Parameters
+		----------
+		self: SimulatedTimeSeries instance
+		chunk: int
+			"chunk size", i.e. number of values to produce
+
+		Returns
+		-------
+		list consisting of `chunk` (time, ts_value) pairs
+		"""
+
+		try:
+			produced = [(next(self.times), next(self.values)) for _ in range(chunk)]
+
+		except StopIteration:
+			# not sure what the optimal error type is here
+			raise IndexError("Make sure you don't produce more values than the generator has!")

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -231,7 +231,7 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 			pretty_printed = "[{} {} {}, ..., {} {} {}]".format(*needed)
 
 		else:
-			pretty_printed = "{} {}".format(list(self._values), list(self._times))
+			pretty_printed = "{}".format(list(self._values))
 
 		return pretty_printed
 

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -119,12 +119,30 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 	# makes check lengths redundant. However I keep them separate in case we want 
     # to add functionality to add objects without a defined time dimension later.
 	@staticmethod
-	def _check_time_domains_helper(lhs , rhs):
+	def _check_time_domains_helper(lhs, rhs):
 		if not lhs._times==rhs._times:
 			raise ValueError(str(lhs)+' and '+str(rhs)+' must have identical time domains')
 
-
-
+	@staticmethod
+	def is_sequence(seq):
+		"""
+		Description
+		-----------
+		Checks if `seq` is a sequence by verifying if it implements __iter__.
+		Parameters
+		----------
+		seq: sequence
+		
+		Notes
+		-----
+		A better implementation might be to use
+		and isinstance(seq, collections.Sequence)
+		"""
+		try:
+			_ = iter(seq)
+		except TypeError as te:
+			# J: unified string formatting with .format()
+			raise TypeError("{} is not a valid sequence".format(seq))
 
 
 

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -15,6 +15,10 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 	# of SizedContainerTimeSeriesInterface implement
 	# self._values and self._times ??
 
+	# J: maximum length of `values` after which
+	# abbreviation will occur in __str__() and __repr__()
+	MAX_LENGTH = 10
+
 	###############################################################
 	## Abstract methods that are defined differently for different
 	## subclasses of SizedContainerTimeSeriesInterface

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -1,0 +1,130 @@
+from timeseriesinterface import TimeSeriesInterface
+import abc
+
+class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
+	"""
+	Description
+	-----------
+	Abstract interface class for a TimeSeries of a fixed size.
+	"""
+
+	
+	##############################################################################
+	## ABSTRACT METHODS TO BE IMPLEMENTED BY ALL TIMESERIES OF FIXED LENGTH
+	##############################################################################
+
+	#J: Should these interfaces also contain implementations?
+	# Python doesn't seem to make a real distinction between
+	# Interfaces and ABCs! See http://bit.ly/2eOU0tk
+	@abc.abstractmethod
+	def __len__(self):
+		"""
+		Description
+		-----------
+		All TimeSeries of fixed length must implement __len__
+		"""
+		pass
+
+	@abc.abstractmethod
+	def __getitem__(self):
+		"""
+		Description
+		-----------
+		All TimeSeries of fixed length must support index-based item retrieval
+		"""
+
+	@abc.abstractmethod
+	def __setitem__(self):
+		"""
+		Description
+		-----------
+		All TimeSeries of fixed length must support index-based item retrieval
+		"""
+		pass
+
+	@abc.abstractmethod
+	def __contains__(self, needle):
+		"""
+		Description
+		-----------
+		A TimeSeries of fixed length must support checking whether it contains an item
+		"""
+		pass
+
+	@abc.abstractmethod
+	def __repr__(self):
+		"""
+		Description
+		-----------
+		Internal String representation for TimeSeries
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __str__(self):
+		"""
+		Description
+		-----------
+		User-friendly representation for TimeSeries
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __abs__(self):
+		"""
+		Description
+		-----------
+		"Absolute value" of TimeSeries, e.g. vector norm
+		"""
+		pass
+
+	@abc.abstractmethod
+	def __bool__(self):
+		"""
+		Description
+		-----------
+		Checks if TimeSeries values are empty?
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __eq__(self):
+		"""
+		Description
+		-----------
+		All TimeSeries of fixed size must support equality checking with '=='
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __ne__(self):
+		"""
+		Description
+		-----------
+		All TimeSeries of fixed size must support the '!='' operator
+		"""
+		pass
+
+	##############################################################################
+	## GLOBAL HELPER METHODS FOR ALL CONTAINER TIME SERIES.
+	## NO NEED TO IMPLEMENT IN SUBCLASS.
+	##############################################################################
+
+	@staticmethod
+	def _check_length_helper(lhs , rhs):
+		if not len(lhs)==len(rhs):
+			raise ValueError(str(lhs)+' and '+str(rhs)+' must have the same length')
+
+	
+	# makes check lengths redundant. However I keep them separate in case we want 
+    # to add functionality to add objects without a defined time dimension later.
+	@staticmethod
+	def _check_time_domains_helper(lhs , rhs):
+		if not lhs._times==rhs._times:
+			raise ValueError(str(lhs)+' and '+str(rhs)+' must have identical time domains')
+
+
+
+
+
+

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -1,3 +1,4 @@
+
 from timeseriesinterface import TimeSeriesInterface
 import abc
 
@@ -8,85 +9,27 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 	Abstract interface class for a TimeSeries of a fixed size.
 	"""
 
-	
-	##############################################################################
-	## ABSTRACT METHODS TO BE IMPLEMENTED BY ALL TIMESERIES OF FIXED LENGTH
-	##############################################################################
+	## NOTES (clean up later before tuesday):
+	# J: how to cleanly enforce that all subclasses
+	# of SizedContainerTimeSeriesInterface implement
+	# self._values and self._times ??
 
-	#J: Should these interfaces also contain implementations?
-	# Python doesn't seem to make a real distinction between
-	# Interfaces and ABCs! See http://bit.ly/2eOU0tk
+
+
+	###############################################################
+	## Abstract methods that are defined differently for different
+	## subclasses of SizedContainerTimeSeriesInterface
+	###############################################################
+
 	@abc.abstractmethod
 	def __len__(self):
 		"""
 		Description
 		-----------
-		All TimeSeries of fixed length must implement __len__
+		All TimeSeries of fixed length must implement __len__.
 		"""
 		pass
 
-	@abc.abstractmethod
-	def __getitem__(self):
-		"""
-		Description
-		-----------
-		All TimeSeries of fixed length must support index-based item retrieval
-		"""
-
-	@abc.abstractmethod
-	def __setitem__(self):
-		"""
-		Description
-		-----------
-		All TimeSeries of fixed length must support index-based item retrieval
-		"""
-		pass
-
-	@abc.abstractmethod
-	def __contains__(self, needle):
-		"""
-		Description
-		-----------
-		A TimeSeries of fixed length must support checking whether it contains an item
-		"""
-		pass
-
-	@abc.abstractmethod
-	def __repr__(self):
-		"""
-		Description
-		-----------
-		Internal String representation for TimeSeries
-		"""
-		pass
-	
-	@abc.abstractmethod
-	def __str__(self):
-		"""
-		Description
-		-----------
-		User-friendly representation for TimeSeries
-		"""
-		pass
-	
-	@abc.abstractmethod
-	def __abs__(self):
-		"""
-		Description
-		-----------
-		"Absolute value" of TimeSeries, e.g. vector norm
-		"""
-		pass
-
-	@abc.abstractmethod
-	def __bool__(self):
-		"""
-		Description
-		-----------
-		Checks if TimeSeries values are empty?
-		"""
-		pass
-	
 	@abc.abstractmethod
 	def __eq__(self):
 		"""
@@ -105,22 +48,249 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 		"""
 		pass
 
+	###############################################################
+	## Methods with the same implementation for all subclasses
+	## of SizedContainerTimeSeriesInterface.
+	###############################################################
+
+	def __iter__(self):
+		"""
+		Description
+		-----------
+		Iterates over `self._values`.
+		Equivalent to calling iter() on the instance.
+
+		Parameters
+		----------
+		self: instance of subclass of SizedContainerTimeSeriesInterface
+		"""
+		for val in self._values:
+			yield val
+
+	def itertimes(self):
+		"""
+		Description
+		------------
+		Iterates over the times in `self._times`
+
+		Parameters
+		----------
+		self: instance of subclass of SizedTimeSeriesInterface
+
+		Returns
+		-------
+		Yields values from `self._times`
+
+		Notes
+		-----
+		"""
+		for tim in self._times:
+			yield tim
+
+	def itervalues(self):
+		"""
+		Description
+		------------
+		Iterates over the values of the time eries
+		
+		Parameters
+		----------
+		self: instance of subclass of SizedTimeSeriesInterface
+		
+		Returns
+		-------
+		Yields values from `self._values`
+
+		Notes
+		-----
+		Identical to iter(self)
+		"""
+		for val in self._values:
+			yield val
+
+	def iteritems(self):
+		"""
+			Description
+			------------
+			Iterates over (time, value) tuples of the time series
+
+			Parameters
+			----------
+			self: instance of subclass of SizedTimeSeriesInterface
+
+			Returns
+			-------
+			Yields (time, value) tuples
+
+			Notes
+			-----
+		"""
+		for i in range(len(self._values)):
+			yield self._times[i], self._values[i]
+
+	def __getitem__(self, index):
+		"""
+		Description
+		-----------
+		Instance method for indexing into a fixed-size Time Series.
+
+		Parameters
+		----------
+		self: instance of subclass of SizedContainerTimeSeriesInterface
+
+		Returns
+		-------
+		The value of `self._values` located at index `index`.
+		"""
+		try:    
+			return self._values[index]
+		except IndexError:
+			raise IndexError("Index out of bounds!")
+
+	def __setitem__(self, index, item):
+		"""
+		Description
+		-----------
+		Sets the element of `self._values`
+		at index `index` equal to `item`. 
+
+		Parameters
+		----------
+		self: instance of subclass of SizedContainerTimeSeriesInterface
+		index: int
+			index to change values at
+		item: tuple
+			(time, value) tuple
+		"""
+		try:
+			self._values[index] = item
+		except IndexError:
+			raise IndexError("Index out of bounds!")
+
+	def __contains__(self, needle):
+		"""
+		Description
+		-----------
+		Checks if `needle` is contained in `self._values`
+
+		Parameters
+		----------
+		self: instance of subclass of SizedContainerTimeSeriesInterface
+		needle: float
+			Time series value to search for
+
+		Returns
+		-------
+		True if `needle` found in `self._values`, else False
+		"""
+		return needle in self._values
+
+	def __repr__(self):
+		"""
+		Description
+		-----------
+		Internal String representation for all subclasses of
+		SizedContainerTimeSeriesInstance
+		"""
+		class_name = self.__class__.__name__
+		return '{}(Length: {}, {})'.format(class_name,
+											len(self._values),
+											str(self))
+	
+	def __str__(self):
+		"""
+		Description
+		-----------
+		Instance method for pretty-printing the time series contents.
+
+		Parameters
+		----------
+		self: instance of subclass of SizedContainerTimeSeriesInterface
+
+		Returns
+		-------
+		pretty_printed: string
+		    an end-user-friendly printout of the time series.
+		    If `len(self._values) > MAX_LENGTH`, printout abbreviated
+		    using an ellipsis: `['a','b','c', ..., 'x','y','z']`.
+
+		Notes
+		-----
+		PRE:
+		POST:
+
+		INVARIANTS:
+
+		WARNINGS:
+		"""
+		if len(self._values) > self.MAX_LENGTH:
+			needed = self._values[:3]+self._values[-3:]
+			pretty_printed = "[{} {} {}, ..., {} {} {}]".format(*needed)
+
+		else:
+			pretty_printed = "{} {}".format(list(self._values), list(self._times))
+
+		return pretty_printed
+
+	
+	def __abs__(self):
+		"""
+		Description
+		-----------
+		Returns the L2-norm of `self._values`
+
+		Parameters
+		----------
+		self: instance of subclass of SizedContainerTimeSeriesInterface
+
+		Returns
+		-------
+		L2-norm as a float
+
+		Notes
+		-----
+		Casts `self._values` into a np-array for fasted norm calcualtion.
+		This won't impact the final return value, as it is a float.
+		"""
+		return (np.array(self._values)**2).sum()
+
+	def __bool__(self):
+		"""
+		Description
+		-----------
+		Checks if `self._values` is empty.
+
+		Parameters
+		----------
+		self: instance of subclass of SizedContainerTimeSeriesInterface
+
+		Returns
+		-------
+		True/False
+		"""
+		return bool(abs(self._values))
+
+
 	##############################################################################
 	## GLOBAL HELPER METHODS FOR ALL CONTAINER TIME SERIES.
 	## NO NEED TO IMPLEMENT IN SUBCLASS.
 	##############################################################################
 
 	@staticmethod
-	def _check_length_helper(lhs , rhs):
+	def _check_length_helper(lhs, rhs):
 		if not len(lhs)==len(rhs):
 			raise ValueError(str(lhs)+' and '+str(rhs)+' must have the same length')
 
 	
 	# makes check lengths redundant. However I keep them separate in case we want 
-    # to add functionality to add objects without a defined time dimension later.
+	# to add functionality to add objects without a defined time dimension later.
 	@staticmethod
 	def _check_time_domains_helper(lhs, rhs):
-		if not lhs._times==rhs._times:
+
+		# J: casting to list here since comparing np.arrays
+		# with == yields a boolean array with results of elemwise
+		# comparinsons.
+		if not list(lhs._times)==list(rhs._times):
 			raise ValueError(str(lhs)+' and '+str(rhs)+' must have identical time domains')
 
 	@staticmethod
@@ -143,6 +313,3 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 		except TypeError as te:
 			# J: unified string formatting with .format()
 			raise TypeError("{} is not a valid sequence".format(seq))
-
-
-

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -1,5 +1,6 @@
 
 from timeseriesinterface import TimeSeriesInterface
+import numpy as np
 import abc
 
 class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
@@ -13,8 +14,6 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 	# J: how to cleanly enforce that all subclasses
 	# of SizedContainerTimeSeriesInterface implement
 	# self._values and self._times ??
-
-
 
 	###############################################################
 	## Abstract methods that are defined differently for different
@@ -269,6 +268,17 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 		True/False
 		"""
 		return bool(abs(self._values))
+
+
+	# J: why do these return np.arrays? 
+	def values(self):
+		return np.array(self._values)
+
+	def times(self):
+		return np.array(self._times)
+
+	def items(self):
+		return list(zip(self._times, self._values))
 
 
 	##############################################################################

--- a/timeseries/streamtimeseriesinterface.py
+++ b/timeseries/streamtimeseriesinterface.py
@@ -1,0 +1,34 @@
+# Implements StreamTimeSeriesInterface ABC.
+
+from timeseriesinterface import TimeSeriesInterface
+import abc
+
+class StreamTimeSeriesInterface(TimeSeriesInterface):
+
+	# just making sure that these don't conflict with
+	# the @abstractmethods in TimeSeriesInterface
+	def __add__(self):
+		pass 
+	def __iter__(self):
+		pass
+	def __mul__(self):
+		pass
+	def __neg__(self):
+		pass
+	def __pos__(self):
+		pass
+	def __radd__(self):
+		pass
+	def __rmul__(self):
+		pass
+	def __rsub__(self):
+		pass
+	def __sub__(self):
+		pass
+
+	# need a way to represent these objects
+	# def __repr__(self):
+	# 	pass
+
+	# def __str__(self):
+	# 	pass

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -89,12 +89,15 @@ def correct_length(class_name):
     ts = class_name(values=[1] * 100, times=range(100))
     assert len(ts) == 100
 
-def update_get_array_time_series_by_index(class_name):
-    """ Confirm that we can set a new time and value for a given index in ArrayTimeSeries"""
-    ts = class_name(values=[1,2,3,4,5],times=[1,2,3,4,5])
-    assert ts[1] == (2,2)
-    ts[1] = (42,42)
-    assert ts[1] == (42,42)
+
+# J: why are we using `class_name` as an arg
+# if this is only to be used for ArrayTimeSeries
+# def update_get_array_time_series_by_index(class_name):
+#     """ Confirm that we can set a new time and value for a given index in ArrayTimeSeries"""
+#     ts = class_name(values=[1,2,3,4,5],times=[1,2,3,4,5])
+#     assert ts[1] == (2,2)
+#     ts[1] = (42,42)
+#     assert ts[1] == (42,42)
 
 def interpolate_ts(class_name):
     a = class_name(values=[1,2,3],times=[0,5,10])
@@ -148,7 +151,11 @@ def test_array_time_series():
     # threes_fives(ArrayTimeSeries)
     non_iterable(ArrayTimeSeries)
     iterable(ArrayTimeSeries)
-    update_get_array_time_series_by_index(ArrayTimeSeries)
+    
+    # J: disabled this since __getitem__ and __setitem__
+    # now inherited from base class
+    #update_get_array_time_series_by_index(ArrayTimeSeries)
+    
     interpolate_ts(ArrayTimeSeries)
     incompatible_dimensions(ArrayTimeSeries)
     # These should work but don't -- need to look into further

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -155,7 +155,7 @@ def test_array_time_series():
     # J: disabled this since __getitem__ and __setitem__
     # now inherited from base class
     #update_get_array_time_series_by_index(ArrayTimeSeries)
-    
+
     interpolate_ts(ArrayTimeSeries)
     incompatible_dimensions(ArrayTimeSeries)
     # These should work but don't -- need to look into further

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -1,6 +1,7 @@
 from pytest import raises
 from timeseries import TimeSeries
 from arraytimeseries import ArrayTimeSeries
+from simulatedtimeseries import SimulatedTimeSeries
 import numpy as np
 from lazy import lazy
 from lazy import LazyOperation
@@ -155,7 +156,6 @@ def test_array_time_series():
     #correct_length(ArrayTimeSeries)
     #times_contains_repeats(ArrayTimeSeries)
 
-
 # The following tests are interface checks - easy examples that don't handle edge cases
 
 def test_interface():
@@ -180,6 +180,7 @@ def test_interface():
     method_mul_two_timeseries(TimeSeries)
     method_eq(TimeSeries)
     method_ne(TimeSeries)
+    method_produce(SimulatedTimeSeries)
 
 # should have made a fixture sorry!
 def method_getitem(class_name):
@@ -299,3 +300,9 @@ def method_ne(class_name):
     eq_v1 = class_name(values=range(0, 10, 3),times=range(100,104))
     eq_v2 = -eq_v1
     assert eq_v1!=eq_v2
+
+def method_produce(class_name):
+    t = iter(range(1,11))
+    v = iter([2*x + 1 for x in range(1,11)])
+    sts = class_name(t, v)
+    assert sts.produce(3) == [(1,3), (2,5), (3,7)]

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -180,7 +180,7 @@ def test_interface():
     method_mul_two_timeseries(TimeSeries)
     method_eq(TimeSeries)
     method_ne(TimeSeries)
-    method_produce(SimulatedTimeSeries)
+    method_produce()
 
 # should have made a fixture sorry!
 def method_getitem(class_name):
@@ -301,8 +301,8 @@ def method_ne(class_name):
     eq_v2 = -eq_v1
     assert eq_v1!=eq_v2
 
-def method_produce(class_name):
+def method_produce():
     t = iter(range(1,11))
     v = iter([2*x + 1 for x in range(1,11)])
-    sts = class_name(t, v)
+    sts = SimulatedTimeSeries(t, v)
     assert sts.produce(3) == [(1,3), (2,5), (3,7)]

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -82,7 +82,7 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
         return len(self._values)
 
 
-    #### ABSTRACT FNS BELOW; REMOVE THIS LATER ######
+    #### ABSTRACT THE METHODS BELOW TO BASE CLASS; REMOVE THIS LATER ######
 
     # J: new implementation inherited from parent class.
     # leaving this here in case need to debug tests....
@@ -100,15 +100,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
     #     # R: leverages self._values is a list. 
     #     # Will have to change when we relax this.
     #     return needle in self._values
-
-    def values(self):
-        return np.array(self._values)
-
-    def times(self):
-        return np.array(self._times)
-
-    def items(self):
-        return list(zip(self._times, self._values))
 
 
     def __neg__(self):

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -1,9 +1,10 @@
+from sizedcontainertimeseriesinterface import SizedContainerTimeSeriesInterface
+from lazy import LazyOperation
+from lazy import lazy
 import numpy as np
 import numbers
-from lazy import lazy
-from lazy import LazyOperation
 
-class TimeSeries:
+class TimeSeries(SizedContainerTimeSeriesInterface):
     """
     A class that stores a single, ordered set of numerical data.
 
@@ -95,6 +96,7 @@ class TimeSeries:
         except IndexError:
             raise IndexError("Index out of bounds!")
 
+    # J: should this not iterate over tuples?
     def __iter__(self):
         for val in self._values:
             yield val
@@ -167,17 +169,6 @@ class TimeSeries:
 
         return pretty_printed
 
-    @staticmethod
-    def _check_length_helper(lhs , rhs):
-        if not len(lhs)==len(rhs):
-            raise ValueError(str(lhs)+' and '+str(rhs)+' must have the same length')
-
-    @staticmethod
-    # makes check lengths redundant. However I keep them separate in case we want to add functionality to add objects without a defined time dimension later.
-    def _check_time_domains_helper(lhs , rhs):
-        if not lhs._times==rhs._times:
-            raise ValueError(str(lhs)+' and '+str(rhs)+' must have identical time domains')
-
     def __abs__(self):
         return math.sqrt(sum(x * x for x in self._values))
 
@@ -217,6 +208,7 @@ class TimeSeries:
         except TypeError:
             raise NotImplemented
 
+    # J: should this not be (self - other)?
     def __rsub__(self, other):
         return -(self - other)
 
@@ -246,29 +238,6 @@ class TimeSeries:
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
-    def is_sequence(self, seq):
-        """
-        Description
-        -----------
-        Checks if `seq` is a sequence by verifying if it implements __iter__.
-
-        Parameters
-        ----------
-        self: TimeSeries instance
-        seq: sequence
-
-        Notes
-        -----
-        A better implementation might be to use
-        and isinstance(seq, collections.Sequence)
-        """
-        try:
-            _ = iter(seq)
-        except TypeError as te:
-            # J: unified string formatting with .format()
-            raise TypeError("{} is not a valid sequence".format(seq))
-
 
     def interpolate(self,ts_to_interpolate):
         """

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -29,10 +29,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
     - Does not maintain an accurate time series if `input_data` is unsorted.
     """
 
-    # J: maximum length of `values` after which
-    # abbreviation will occur in __str__() and __repr__()
-    MAX_LENGTH = 10
-
     def __init__(self, values, times=None):
         """
         The TimeSeries class constructor. It must be provided the initial data

--- a/timeseries/timeseriesinterface.py
+++ b/timeseries/timeseriesinterface.py
@@ -1,0 +1,90 @@
+# Implements the TimeSeriesInterface ABC 
+
+import abc
+
+class TimeSeriesInterface(abc.ABC):
+	"""Interface for TimeSeries"""
+
+	##############################################################################
+	## GLOBAL CONSTANT FOR ALL TIMESERIES
+	##############################################################################
+	MAX_LENGTH = 10
+
+	##############################################################################
+	## ABSTRACT METHODS TO BE IMPLEMENTED BY ALL TIMESERIES OF FIXED LENGTH
+	##############################################################################
+
+	@abc.abstractmethod
+	def __iter__(self):
+		"""
+		Description
+		-----------
+		Fixed size or not, each TimeSeries needs to support iteration.
+		"""
+		pass
+
+	@abc.abstractmethod
+	def __neg__(self):
+		"""
+		Description
+		-----------
+		All TimeSeries, fixed or not, should support unary `-` operator
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __pos__(self):
+		"""
+		Description
+		-----------
+		Obviously all TimeSeries need to suppport opposite of __neg__ as well.
+		"""
+		pass
+	
+
+	# J: I'm assuming these methods can be implemented lazily,
+	# so including them at the top of the hierarchy...
+
+	@abc.abstractmethod
+	def __add__(self, rhs):
+		"""
+		Description
+		-----------
+		All TimeSeries should support adding a constant to each element
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __radd__(self, other):
+		"""
+		Description
+		-----------
+		All TimeSeries should support adding a constant to each element
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __sub__(self, rhs):
+		"""
+		Description
+		-----------
+		All TimeSeries should support subtracting a constant from each element
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __rsub__(self, other):
+		pass
+	
+	@abc.abstractmethod
+	def __mul__(self, rhs):
+		"""
+		Description
+		-----------
+		All TimeSeries must support multiplication by a constant
+		"""
+		pass
+	
+	@abc.abstractmethod
+	def __rmul__(self):
+		pass

--- a/timeseries/timeseriesinterface.py
+++ b/timeseries/timeseriesinterface.py
@@ -62,7 +62,7 @@ class TimeSeriesInterface(abc.ABC):
 		All TimeSeries should support adding a constant to each element
 		"""
 		pass
-	
+
 	@abc.abstractmethod
 	def __sub__(self, rhs):
 		"""


### PR DESCRIPTION
I did some more work but unfortunately have to tackle other psets because literally all my classwork is due at the same time on Tuesday.

Here's what changed and what needs to be done (I also put these on the wiki):
- I abstracted a bunch of methods to SizedContainerTimeSeriesInterface
- Changed __str__ and __repr__ to only print values, not times. This was done to harmonize what happens between TimeSeries and ArrayTimeSeries. I think this could be changed to printing (time, value) tuples as well. 
- __getitem__ and __setitem__ are now part of the base class. Because of that, ArrayTimeSeries[i] also now only returns a value, not a tuple

Todo: 
- abstract the rest of the dunder methods in TimeSeries and ArrayTimeSeries to the ABC SizedContainerTimeSeriesInterface.