### PR TITLE
Milestone1 additional abc work

### DIFF
--- a/timeseries/arraytimeseries.py
+++ b/timeseries/arraytimeseries.py
@@ -49,8 +49,6 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
 
     def __eq__(self, rhs):
         # Note: np.array_equal compares both elements and dimensions.
-        #print("array check",self,rhs)
-        #print("type check",type(self),type(rhs))
         self.__class__._check_time_domains_helper(self, rhs)
         try:
             return (np.array_equal(self._values,rhs._values) and np.array_equal(self._times,rhs._times))
@@ -61,6 +59,10 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
 
 
     def __add__ (self,rhs):
+        # N: Note – currently, we’re adding the value arrays if everything is the same length.
+        # N: But it would be possible to have to time series that were the same length but which
+        # N: covered different times. Should we address this as well?
+
         try:
             if isinstance(rhs, numbers.Real):
                 return self.__class__(values=(self._values + rhs), times=self._times)

--- a/timeseries/arraytimeseries.py
+++ b/timeseries/arraytimeseries.py
@@ -37,7 +37,7 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
 
         if len(self._times) != len(set(self._times)):
             raise ValueError("Time data should contain no repeats")
-    
+
     def __len__(self):
         # Note: len of np.appry returns and error for arrays of size 1.
         #super().__len__()
@@ -48,6 +48,8 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
 
     def __eq__(self, rhs):
         # Note: np.array_equal compares both elements and dimensions.
+        #print("array check",self,rhs)
+        #print("type check",type(self),type(rhs))
         self.__class__._check_time_domains_helper(self, rhs)
         try:
             return (np.array_equal(self._values,rhs._values) and np.array_equal(self._times,rhs._times))
@@ -55,56 +57,6 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
         except TypeError:
             raise NotImplemented
 
-    # imo we should consider implementing this in
-    # SizedContainerTimeSeriesInterface...
-    def interpolate(self,ts_to_interpolate):
-        """
-        Returns new TimeSeries instance with piecewise-linear-interpolated values
-        for submitted time-times.If called times are outside of the domain of the existing
-        Time Series, the minimum or maximum values are returned.
-
-        Parameters
-        ----------
-        self: TimeSeries instance
-        ts_to_interpolate: list or other sequence of times to be interpolated
-
-        """
-        def binary_search(times, t):
-            """ Returns surrounding time indexes for value that is to be interpolated"""
-            min = 0
-            max = len(times) - 1
-            while True:
-                if max < min:
-                    return (max,min)
-                m = (min + max) // 2
-                if times[m] < t:
-                    min = m + 1
-                elif times[m] > t:
-                    max = m - 1
-                else: #Should never hit this case in current implementation
-                    return (min,max)
-
-        def interpolate_val(times,values,t):
-            """Returns interpolated value for given time"""
-
-            if t in times:          #time already exits in ts -- return it
-                return values[times.index(t)]
-
-            elif t >= times[-1]:    #time is above the domain of the existing values -- return max time value
-                return values[-1]
-
-            elif t <= times[0]:     #time is below the domain of the existing values -- return min time value
-                return values[0]
-
-            else:                   #time is between two existing points -- interpolate it
-                low,high = binary_search(times, t)
-                slope = (float(values[high]) - values[low])/(times[high] - times[low])
-                c = values[low]
-                interpolated_val = (t-times[low])*slope + c
-                return interpolated_val
-
-        interpolated_ts = [interpolate_val(self._times,self._values,t) for t in ts_to_interpolate]
-        return self.__class__(values=interpolated_ts,times=ts_to_interpolate)
 
     # J: these methods need to be implemented
     def __add__ (self):
@@ -114,9 +66,11 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
     def __ne__(self):
         pass
     def __neg__(self):
-        pass
+        return self.__class__(values=((-1)*self._values), times=self._times)
+
     def __pos__(self):
-        pass
+        return self.__class__(values=self._values, times=self._times)
+
     def __radd__(self):
         pass
     def __rmul__(self):

--- a/timeseries/arraytimeseries.py
+++ b/timeseries/arraytimeseries.py
@@ -1,5 +1,6 @@
 from sizedcontainertimeseriesinterface import SizedContainerTimeSeriesInterface
 import numpy as np
+import numbers
 
 class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
     """
@@ -58,24 +59,43 @@ class ArrayTimeSeries(SizedContainerTimeSeriesInterface):
             raise NotImplemented
 
 
-    # J: these methods need to be implemented
-    def __add__ (self):
-        pass
-    def __mul__(self):
-        pass
-    def __ne__(self):
-        pass
+
+    def __add__ (self,rhs):
+        try:
+            if isinstance(rhs, numbers.Real):
+                return self.__class__(values=(self._values + rhs), times=self._times)
+            else:
+                self._check_length_helper(self, rhs)
+                self._check_time_domains_helper(self, rhs)
+                return self.__class__(values=self._values + rhs._values, times=self._times)
+        except TypeError:
+            raise NotImplemented
+
+    def __sub__(self, rhs):
+        try:
+            if isinstance(rhs, numbers.Real):
+                return self.__class__(values=(self._values - rhs), times=self._times)
+            else:
+                self._check_length_helper(self, rhs)
+                self._check_time_domains_helper(self, rhs)
+                return self.__class__(values=self._values - rhs._values, times=self._times)
+        except TypeError:
+            raise NotImplemented
+
+    def __mul__(self, rhs):
+        try:
+            if isinstance(rhs, numbers.Real):
+                return self.__class__(values=(self._values * rhs), times=self._times)
+            else:
+                self._check_length_helper(self, rhs)
+                self._check_time_domains_helper(self, rhs)
+                pairs = zip(self._values, rhs)
+                return self.__class__(values=self._values * rhs._values, times=self._times)
+        except TypeError:
+            raise NotImplemented
+
     def __neg__(self):
         return self.__class__(values=((-1)*self._values), times=self._times)
 
     def __pos__(self):
         return self.__class__(values=self._values, times=self._times)
-
-    def __radd__(self):
-        pass
-    def __rmul__(self):
-        pass
-    def __rsub__(self):
-        pass
-    def __sub__(self):
-        pass

--- a/timeseries/lazy.py
+++ b/timeseries/lazy.py
@@ -1,34 +1,34 @@
 class LazyOperation():
-	"""
-		This is the thunk.
-	"""
-	def __init__(self, function, *args, **kwargs):
-		self._function = function
-		self._args = args
-		self._kwargs = kwargs
+    """
+        This is the thunk.
+    """
+    def __init__(self, function, *args, **kwargs):
+        self._function = function
+        self._args = args
+        self._kwargs = kwargs
 
-	def eval(self):
-		# Recursively eval() lazy args
-		new_args = [a.eval() if isinstance(a,LazyOperation) else a for a in self._args]
-		new_kwargs = {k:v.eval() if isinstance(v,LazyOperation) else v for k,v in self._kwargs.items()}
+    def eval(self):
+        # Recursively eval() lazy args
+        new_args = [a.eval() if isinstance(a,LazyOperation) else a for a in self._args]
+        new_kwargs = {k:v.eval() if isinstance(v,LazyOperation) else v for k,v in self._kwargs.items()}
 
-		return self._function(*new_args, **new_kwargs)
+        return self._function(*new_args, **new_kwargs)
 
 def lazy(function):
-	"""
-		A lazy decorator to create a thunk/function - return a LazyOperation instance
-	"""
-	def create_thunk(*args, **kwargs):
-		return LazyOperation(function, *args, **kwargs)
-	return create_thunk
+    """
+        A lazy decorator to create a thunk/function - return a LazyOperation instance
+    """
+    def create_thunk(*args, **kwargs):
+        return LazyOperation(function, *args, **kwargs)
+    return create_thunk
 
 """
-	lazy_add and a lazy_mul to be used to write tests for lazy.py.
+    lazy_add and a lazy_mul to be used to write tests for lazy.py.
 """
 @lazy
 def lazy_add(a,b):
-	return a+b
+    return a+b
 
 @lazy
 def lazy_mul(a,b):
-	return a*b
+    return a*b

--- a/timeseries/simulatedtimeseries.py
+++ b/timeseries/simulatedtimeseries.py
@@ -1,46 +1,46 @@
 from streamtimeseriesinterface import StreamTimeSeriesInterface
 
 class SimulatedTimeSeries(StreamTimeSeriesInterface):
-	"""
-	Description
-	-----------
-	Implements a Time Series without a fixed storage.
-	Uses generators to produce a streaming effect.
+    """
+    Description
+    -----------
+    Implements a Time Series without a fixed storage.
+    Uses generators to produce a streaming effect.
 
-	Parameters
-	----------
-	times_gen: generator
-		lazily evaluated generator representing time values
-	values: generator
-		lazily evaluated generator representing data values
-	"""
-	def __init__(self, times_gen, values_gen):
-		super(SimulatedTimeSeries, self).__init__()
-		self.times = times_gen
-		self.values = values_gen
+    Parameters
+    ----------
+    times_gen: generator
+        lazily evaluated generator representing time values
+    values: generator
+        lazily evaluated generator representing data values
+    """
+    def __init__(self, times_gen, values_gen):
+        super(SimulatedTimeSeries, self).__init__()
+        self.times = times_gen
+        self.values = values_gen
 
-	def produce(self, chunk):
-		"""
-		Description
-		-----------
-		Produces `chunk` new values of the time series
+    def produce(self, chunk):
+        """
+        Description
+        -----------
+        Produces `chunk` new values of the time series
 
-		Parameters
-		----------
-		self: SimulatedTimeSeries instance
-		chunk: int
-			"chunk size", i.e. number of values to produce
+        Parameters
+        ----------
+        self: SimulatedTimeSeries instance
+        chunk: int
+            "chunk size", i.e. number of values to produce
 
-		Returns
-		-------
-		list consisting of `chunk` (time, ts_value) pairs
-		"""
+        Returns
+        -------
+        list consisting of `chunk` (time, ts_value) pairs
+        """
 
-		try:
-			produced = [(next(self.times), next(self.values)) for _ in range(chunk)]
+        try:
+            produced = [(next(self.times), next(self.values)) for _ in range(chunk)]
 
-		except StopIteration:
-			# not sure what the optimal error type is here
-			raise IndexError("Make sure you don't produce more values than the generator has!")
+        except StopIteration:
+            # not sure what the optimal error type is here
+            raise IndexError("Make sure you don't produce more values than the generator has!")
 
-		return produced
+        return produced

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -284,6 +284,12 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
     def items(self):
         return list(zip(self._times, self._values))
 
+    def __neg__(self):
+        return self.__class__((-x for x in self._values), self._times)
+
+    def __pos__(self):
+        return self.__class__((x for x in self._values), self._times)
+
 
     def interpolate(self,ts_to_interpolate):
         """

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -2,6 +2,7 @@
 from timeseriesinterface import TimeSeriesInterface
 import numpy as np
 import abc
+import numbers
 
 class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
     """
@@ -290,6 +291,35 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
     def __pos__(self):
         return self.__class__((x for x in self._values), self._times)
 
+    def __add__(self, rhs):
+        try:
+            if isinstance(rhs, numbers.Real):
+                # R: may be worth testing time domains are preserved correctly
+                return self.__class__((a + rhs for a in self), self._times)
+            else:
+                self._check_length_helper(self, rhs)
+                # R: test me. should fail when the time domains are non congruent
+                self._check_time_domains_helper(self, rhs)
+                pairs = zip(self._values, rhs)
+                return self.__class__((a + b for a, b in pairs), self._times)
+        except TypeError:
+            raise NotImplemented # R: test me. should fail when we try to add a numpy array or list
+
+
+    def __radd__(self, other): # other + self delegates to self.__add__
+        return self + other
+
+    def __sub__(self, rhs):
+        try:
+            if isinstance(rhs, numbers.Real):
+                return self.__class__((a - rhs for a in self), self._times)
+            else:
+                self._check_length_helper(self, rhs)
+                self._check_time_domains_helper(self, rhs)
+                pairs = zip(self._values, rhs)
+                return self.__class__((a - b for a, b in pairs), self._times)
+        except TypeError:
+            raise NotImplemented
 
     def interpolate(self,ts_to_interpolate):
         """

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -4,326 +4,326 @@ import numpy as np
 import abc
 
 class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
-	"""
-	Description
-	-----------
-	Abstract interface class for a TimeSeries of a fixed size.
-	"""
+    """
+    Description
+    -----------
+    Abstract interface class for a TimeSeries of a fixed size.
+    """
 
-	## NOTES (clean up later before tuesday):
-	# J: how to cleanly enforce that all subclasses
-	# of SizedContainerTimeSeriesInterface implement
-	# self._values and self._times ??
+    ## NOTES (clean up later before tuesday):
+    # J: how to cleanly enforce that all subclasses
+    # of SizedContainerTimeSeriesInterface implement
+    # self._values and self._times ??
 
-	# J: maximum length of `values` after which
-	# abbreviation will occur in __str__() and __repr__()
-	MAX_LENGTH = 10
+    # J: maximum length of `values` after which
+    # abbreviation will occur in __str__() and __repr__()
+    MAX_LENGTH = 10
 
-	###############################################################
-	## Abstract methods that are defined differently for different
-	## subclasses of SizedContainerTimeSeriesInterface
-	###############################################################
+    ###############################################################
+    ## Abstract methods that are defined differently for different
+    ## subclasses of SizedContainerTimeSeriesInterface
+    ###############################################################
 
-	@abc.abstractmethod
-	def __len__(self):
-		"""
-		Description
-		-----------
-		All TimeSeries of fixed length must implement __len__.
-		"""
-		pass
+    @abc.abstractmethod
+    def __len__(self):
+        """
+        Description
+        -----------
+        All TimeSeries of fixed length must implement __len__.
+        """
+        pass
 
-	@abc.abstractmethod
-	def __eq__(self):
-		"""
-		Description
-		-----------
-		All TimeSeries of fixed size must support equality checking with '=='
-		"""
-		pass
-	
-	@abc.abstractmethod
-	def __ne__(self):
-		"""
-		Description
-		-----------
-		All TimeSeries of fixed size must support the '!='' operator
-		"""
-		pass
+    @abc.abstractmethod
+    def __eq__(self):
+        """
+        Description
+        -----------
+        All TimeSeries of fixed size must support equality checking with '=='
+        """
+        pass
 
-	###############################################################
-	## Methods with the same implementation for all subclasses
-	## of SizedContainerTimeSeriesInterface.
-	###############################################################
+    @abc.abstractmethod
+    def __ne__(self):
+        """
+        Description
+        -----------
+        All TimeSeries of fixed size must support the '!='' operator
+        """
+        pass
 
-	def __iter__(self):
-		"""
-		Description
-		-----------
-		Iterates over `self._values`.
-		Equivalent to calling iter() on the instance.
+    ###############################################################
+    ## Methods with the same implementation for all subclasses
+    ## of SizedContainerTimeSeriesInterface.
+    ###############################################################
 
-		Parameters
-		----------
-		self: instance of subclass of SizedContainerTimeSeriesInterface
-		"""
-		for val in self._values:
-			yield val
+    def __iter__(self):
+        """
+        Description
+        -----------
+        Iterates over `self._values`.
+        Equivalent to calling iter() on the instance.
 
-	def itertimes(self):
-		"""
-		Description
-		------------
-		Iterates over the times in `self._times`
+        Parameters
+        ----------
+        self: instance of subclass of SizedContainerTimeSeriesInterface
+        """
+        for val in self._values:
+            yield val
 
-		Parameters
-		----------
-		self: instance of subclass of SizedTimeSeriesInterface
+    def itertimes(self):
+        """
+        Description
+        ------------
+        Iterates over the times in `self._times`
 
-		Returns
-		-------
-		Yields values from `self._times`
+        Parameters
+        ----------
+        self: instance of subclass of SizedTimeSeriesInterface
 
-		Notes
-		-----
-		"""
-		for tim in self._times:
-			yield tim
+        Returns
+        -------
+        Yields values from `self._times`
 
-	def itervalues(self):
-		"""
-		Description
-		------------
-		Iterates over the values of the time eries
-		
-		Parameters
-		----------
-		self: instance of subclass of SizedTimeSeriesInterface
-		
-		Returns
-		-------
-		Yields values from `self._values`
+        Notes
+        -----
+        """
+        for tim in self._times:
+            yield tim
 
-		Notes
-		-----
-		Identical to iter(self)
-		"""
-		for val in self._values:
-			yield val
+    def itervalues(self):
+        """
+        Description
+        ------------
+        Iterates over the values of the time eries
 
-	def iteritems(self):
-		"""
-			Description
-			------------
-			Iterates over (time, value) tuples of the time series
+        Parameters
+        ----------
+        self: instance of subclass of SizedTimeSeriesInterface
 
-			Parameters
-			----------
-			self: instance of subclass of SizedTimeSeriesInterface
+        Returns
+        -------
+        Yields values from `self._values`
 
-			Returns
-			-------
-			Yields (time, value) tuples
+        Notes
+        -----
+        Identical to iter(self)
+        """
+        for val in self._values:
+            yield val
 
-			Notes
-			-----
-		"""
-		for i in range(len(self._values)):
-			yield self._times[i], self._values[i]
+    def iteritems(self):
+        """
+            Description
+            ------------
+            Iterates over (time, value) tuples of the time series
 
-	def __getitem__(self, index):
-		"""
-		Description
-		-----------
-		Instance method for indexing into a fixed-size Time Series.
+            Parameters
+            ----------
+            self: instance of subclass of SizedTimeSeriesInterface
 
-		Parameters
-		----------
-		self: instance of subclass of SizedContainerTimeSeriesInterface
+            Returns
+            -------
+            Yields (time, value) tuples
 
-		Returns
-		-------
-		The value of `self._values` located at index `index`.
-		"""
-		try:    
-			return self._values[index]
-		except IndexError:
-			raise IndexError("Index out of bounds!")
+            Notes
+            -----
+        """
+        for i in range(len(self._values)):
+            yield self._times[i], self._values[i]
 
-	def __setitem__(self, index, item):
-		"""
-		Description
-		-----------
-		Sets the element of `self._values`
-		at index `index` equal to `item`. 
+    def __getitem__(self, index):
+        """
+        Description
+        -----------
+        Instance method for indexing into a fixed-size Time Series.
 
-		Parameters
-		----------
-		self: instance of subclass of SizedContainerTimeSeriesInterface
-		index: int
-			index to change values at
-		item: tuple
-			(time, value) tuple
-		"""
-		try:
-			self._values[index] = item
-		except IndexError:
-			raise IndexError("Index out of bounds!")
+        Parameters
+        ----------
+        self: instance of subclass of SizedContainerTimeSeriesInterface
 
-	def __contains__(self, needle):
-		"""
-		Description
-		-----------
-		Checks if `needle` is contained in `self._values`
+        Returns
+        -------
+        The value of `self._values` located at index `index`.
+        """
+        try:
+            return self._values[index]
+        except IndexError:
+            raise IndexError("Index out of bounds!")
 
-		Parameters
-		----------
-		self: instance of subclass of SizedContainerTimeSeriesInterface
-		needle: float
-			Time series value to search for
+    def __setitem__(self, index, item):
+        """
+        Description
+        -----------
+        Sets the element of `self._values`
+        at index `index` equal to `item`.
 
-		Returns
-		-------
-		True if `needle` found in `self._values`, else False
-		"""
-		return needle in self._values
+        Parameters
+        ----------
+        self: instance of subclass of SizedContainerTimeSeriesInterface
+        index: int
+            index to change values at
+        item: tuple
+            (time, value) tuple
+        """
+        try:
+            self._values[index] = item
+        except IndexError:
+            raise IndexError("Index out of bounds!")
 
-	def __repr__(self):
-		"""
-		Description
-		-----------
-		Internal String representation for all subclasses of
-		SizedContainerTimeSeriesInstance
-		"""
-		class_name = self.__class__.__name__
-		return '{}(Length: {}, {})'.format(class_name,
-											len(self._values),
-											str(self))
-	
-	def __str__(self):
-		"""
-		Description
-		-----------
-		Instance method for pretty-printing the time series contents.
+    def __contains__(self, needle):
+        """
+        Description
+        -----------
+        Checks if `needle` is contained in `self._values`
 
-		Parameters
-		----------
-		self: instance of subclass of SizedContainerTimeSeriesInterface
+        Parameters
+        ----------
+        self: instance of subclass of SizedContainerTimeSeriesInterface
+        needle: float
+            Time series value to search for
 
-		Returns
-		-------
-		pretty_printed: string
-		    an end-user-friendly printout of the time series.
-		    If `len(self._values) > MAX_LENGTH`, printout abbreviated
-		    using an ellipsis: `['a','b','c', ..., 'x','y','z']`.
+        Returns
+        -------
+        True if `needle` found in `self._values`, else False
+        """
+        return needle in self._values
 
-		Notes
-		-----
-		PRE:
-		POST:
+    def __repr__(self):
+        """
+        Description
+        -----------
+        Internal String representation for all subclasses of
+        SizedContainerTimeSeriesInstance
+        """
+        class_name = self.__class__.__name__
+        return '{}(Length: {}, {})'.format(class_name,
+                                            len(self._values),
+                                            str(self))
 
-		INVARIANTS:
+    def __str__(self):
+        """
+        Description
+        -----------
+        Instance method for pretty-printing the time series contents.
 
-		WARNINGS:
-		"""
-		if len(self._values) > self.MAX_LENGTH:
-			needed = self._values[:3]+self._values[-3:]
-			pretty_printed = "[{} {} {}, ..., {} {} {}]".format(*needed)
+        Parameters
+        ----------
+        self: instance of subclass of SizedContainerTimeSeriesInterface
 
-		else:
-			pretty_printed = "{}".format(list(self._values))
+        Returns
+        -------
+        pretty_printed: string
+            an end-user-friendly printout of the time series.
+            If `len(self._values) > MAX_LENGTH`, printout abbreviated
+            using an ellipsis: `['a','b','c', ..., 'x','y','z']`.
 
-		return pretty_printed
+        Notes
+        -----
+        PRE:
+        POST:
 
-	
-	def __abs__(self):
-		"""
-		Description
-		-----------
-		Returns the L2-norm of `self._values`
+        INVARIANTS:
 
-		Parameters
-		----------
-		self: instance of subclass of SizedContainerTimeSeriesInterface
+        WARNINGS:
+        """
+        if len(self._values) > self.MAX_LENGTH:
+            needed = self._values[:3]+self._values[-3:]
+            pretty_printed = "[{} {} {}, ..., {} {} {}]".format(*needed)
 
-		Returns
-		-------
-		L2-norm as a float
+        else:
+            pretty_printed = "{}".format(list(self._values))
 
-		Notes
-		-----
-		Casts `self._values` into a np-array for fasted norm calcualtion.
-		This won't impact the final return value, as it is a float.
-		"""
-		return (np.array(self._values)**2).sum()
-
-	def __bool__(self):
-		"""
-		Description
-		-----------
-		Checks if `self._values` is empty.
-
-		Parameters
-		----------
-		self: instance of subclass of SizedContainerTimeSeriesInterface
-
-		Returns
-		-------
-		True/False
-		"""
-		return bool(abs(self._values))
+        return pretty_printed
 
 
-	# J: why do these return np.arrays? 
-	def values(self):
-		return np.array(self._values)
+    def __abs__(self):
+        """
+        Description
+        -----------
+        Returns the L2-norm of `self._values`
 
-	def times(self):
-		return np.array(self._times)
+        Parameters
+        ----------
+        self: instance of subclass of SizedContainerTimeSeriesInterface
 
-	def items(self):
-		return list(zip(self._times, self._values))
+        Returns
+        -------
+        L2-norm as a float
+
+        Notes
+        -----
+        Casts `self._values` into a np-array for fasted norm calcualtion.
+        This won't impact the final return value, as it is a float.
+        """
+        return (np.array(self._values)**2).sum()
+
+    def __bool__(self):
+        """
+        Description
+        -----------
+        Checks if `self._values` is empty.
+
+        Parameters
+        ----------
+        self: instance of subclass of SizedContainerTimeSeriesInterface
+
+        Returns
+        -------
+        True/False
+        """
+        return bool(abs(self._values))
 
 
-	##############################################################################
-	## GLOBAL HELPER METHODS FOR ALL CONTAINER TIME SERIES.
-	## NO NEED TO IMPLEMENT IN SUBCLASS.
-	##############################################################################
+    # J: why do these return np.arrays?
+    def values(self):
+        return np.array(self._values)
 
-	@staticmethod
-	def _check_length_helper(lhs, rhs):
-		if not len(lhs)==len(rhs):
-			raise ValueError(str(lhs)+' and '+str(rhs)+' must have the same length')
+    def times(self):
+        return np.array(self._times)
 
-	
-	# makes check lengths redundant. However I keep them separate in case we want 
-	# to add functionality to add objects without a defined time dimension later.
-	@staticmethod
-	def _check_time_domains_helper(lhs, rhs):
+    def items(self):
+        return list(zip(self._times, self._values))
 
-		# J: casting to list here since comparing np.arrays
-		# with == yields a boolean array with results of elemwise
-		# comparinsons.
-		if not list(lhs._times)==list(rhs._times):
-			raise ValueError(str(lhs)+' and '+str(rhs)+' must have identical time domains')
 
-	@staticmethod
-	def is_sequence(seq):
-		"""
-		Description
-		-----------
-		Checks if `seq` is a sequence by verifying if it implements __iter__.
-		Parameters
-		----------
-		seq: sequence
-		
-		Notes
-		-----
-		A better implementation might be to use
-		and isinstance(seq, collections.Sequence)
-		"""
-		try:
-			_ = iter(seq)
-		except TypeError as te:
-			# J: unified string formatting with .format()
-			raise TypeError("{} is not a valid sequence".format(seq))
+    ##############################################################################
+    ## GLOBAL HELPER METHODS FOR ALL CONTAINER TIME SERIES.
+    ## NO NEED TO IMPLEMENT IN SUBCLASS.
+    ##############################################################################
+
+    @staticmethod
+    def _check_length_helper(lhs, rhs):
+        if not len(lhs)==len(rhs):
+            raise ValueError(str(lhs)+' and '+str(rhs)+' must have the same length')
+
+
+    # makes check lengths redundant. However I keep them separate in case we want
+    # to add functionality to add objects without a defined time dimension later.
+    @staticmethod
+    def _check_time_domains_helper(lhs, rhs):
+
+        # J: casting to list here since comparing np.arrays
+        # with == yields a boolean array with results of elemwise
+        # comparinsons.
+        if not list(lhs._times)==list(rhs._times):
+            raise ValueError(str(lhs)+' and '+str(rhs)+' must have identical time domains')
+
+    @staticmethod
+    def is_sequence(seq):
+        """
+        Description
+        -----------
+        Checks if `seq` is a sequence by verifying if it implements __iter__.
+        Parameters
+        ----------
+        seq: sequence
+
+        Notes
+        -----
+        A better implementation might be to use
+        and isinstance(seq, collections.Sequence)
+        """
+        try:
+            _ = iter(seq)
+        except TypeError as te:
+            # J: unified string formatting with .format()
+            raise TypeError("{} is not a valid sequence".format(seq))

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -285,41 +285,6 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
     def items(self):
         return list(zip(self._times, self._values))
 
-    def __neg__(self):
-        return self.__class__((-x for x in self._values), self._times)
-
-    def __pos__(self):
-        return self.__class__((x for x in self._values), self._times)
-
-    def __add__(self, rhs):
-        try:
-            if isinstance(rhs, numbers.Real):
-                # R: may be worth testing time domains are preserved correctly
-                return self.__class__((a + rhs for a in self), self._times)
-            else:
-                self._check_length_helper(self, rhs)
-                # R: test me. should fail when the time domains are non congruent
-                self._check_time_domains_helper(self, rhs)
-                pairs = zip(self._values, rhs)
-                return self.__class__((a + b for a, b in pairs), self._times)
-        except TypeError:
-            raise NotImplemented # R: test me. should fail when we try to add a numpy array or list
-
-
-    def __radd__(self, other): # other + self delegates to self.__add__
-        return self + other
-
-    def __sub__(self, rhs):
-        try:
-            if isinstance(rhs, numbers.Real):
-                return self.__class__((a - rhs for a in self), self._times)
-            else:
-                self._check_length_helper(self, rhs)
-                self._check_time_domains_helper(self, rhs)
-                pairs = zip(self._values, rhs)
-                return self.__class__((a - b for a, b in pairs), self._times)
-        except TypeError:
-            raise NotImplemented
 
     def interpolate(self,ts_to_interpolate):
         """

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -276,8 +276,9 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
 
 
     # J: why do these return np.arrays?
+    # N: Switching it to cast to lists for easier testing
     def values(self):
-        return np.array(self._values)
+        return list(self._values)
 
     def times(self):
         return np.array(self._times)
@@ -339,6 +340,18 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
     ## GLOBAL HELPER METHODS FOR ALL CONTAINER TIME SERIES.
     ## NO NEED TO IMPLEMENT IN SUBCLASS.
     ##############################################################################
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __radd__(self, other): # other + self delegates to self.__add__
+        return self + other
+
+    def __rsub__(self, other):
+        return -(self - other)
+
+    def __rmul__(self, other):
+        return self * other
 
     @staticmethod
     def _check_length_helper(lhs, rhs):

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -281,11 +281,10 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
         return list(self._values)
 
     def times(self):
-        return np.array(self._times)
+        return list(self._times)
 
     def items(self):
         return list(zip(self._times, self._values))
-
 
     def interpolate(self,ts_to_interpolate):
         """
@@ -309,10 +308,8 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
                 m = (min + max) // 2
                 if times[m] < t:
                     min = m + 1
-                elif times[m] > t:
+                else:
                     max = m - 1
-                else: #Should never hit this case in current implementation
-                    return (min,max)
 
         def interpolate_val(times,values,t):
             """Returns interpolated value for given time"""

--- a/timeseries/sizedcontainertimeseriesinterface.py
+++ b/timeseries/sizedcontainertimeseriesinterface.py
@@ -285,6 +285,55 @@ class SizedContainerTimeSeriesInterface(TimeSeriesInterface):
         return list(zip(self._times, self._values))
 
 
+    def interpolate(self,ts_to_interpolate):
+        """
+        Returns new TimeSeries instance with piecewise-linear-interpolated values
+        for submitted time-times.If called times are outside of the domain of the existing
+        Time Series, the minimum or maximum values are returned.
+
+        Parameters
+        ----------
+        self: TimeSeries instance
+        ts_to_interpolate: list or other sequence of times to be interpolated
+
+        """
+        def binary_search(times, t):
+            """ Returns surrounding time indexes for value that is to be interpolated"""
+            min = 0
+            max = len(times) - 1
+            while True:
+                if max < min:
+                    return (max,min)
+                m = (min + max) // 2
+                if times[m] < t:
+                    min = m + 1
+                elif times[m] > t:
+                    max = m - 1
+                else: #Should never hit this case in current implementation
+                    return (min,max)
+
+        def interpolate_val(times,values,t):
+            """Returns interpolated value for given time"""
+
+            if t in times:          #time already exits in ts -- return it
+                return values[times.index(t)]
+
+            elif t >= times[-1]:    #time is above the domain of the existing values -- return max time value
+                return values[-1]
+
+            elif t <= times[0]:     #time is below the domain of the existing values -- return min time value
+                return values[0]
+
+            else:                   #time is between two existing points -- interpolate it
+                low,high = binary_search(times, t)
+                slope = (float(values[high]) - values[low])/(times[high] - times[low])
+                c = values[low]
+                interpolated_val = (t-times[low])*slope + c
+                return interpolated_val
+
+        interpolated_ts = [interpolate_val(self._times,self._values,t) for t in ts_to_interpolate]
+        return self.__class__(values=interpolated_ts,times=ts_to_interpolate)
+
     ##############################################################################
     ## GLOBAL HELPER METHODS FOR ALL CONTAINER TIME SERIES.
     ## NO NEED TO IMPLEMENT IN SUBCLASS.

--- a/timeseries/streamtimeseriesinterface.py
+++ b/timeseries/streamtimeseriesinterface.py
@@ -5,30 +5,30 @@ import abc
 
 class StreamTimeSeriesInterface(TimeSeriesInterface):
 
-	# just making sure that these don't conflict with
-	# the @abstractmethods in TimeSeriesInterface
-	def __add__(self):
-		pass 
-	def __iter__(self):
-		pass
-	def __mul__(self):
-		pass
-	def __neg__(self):
-		pass
-	def __pos__(self):
-		pass
-	def __radd__(self):
-		pass
-	def __rmul__(self):
-		pass
-	def __rsub__(self):
-		pass
-	def __sub__(self):
-		pass
+    # just making sure that these don't conflict with
+    # the @abstractmethods in TimeSeriesInterface
+    def __add__(self):
+        pass
+    def __iter__(self):
+        pass
+    def __mul__(self):
+        pass
+    def __neg__(self):
+        pass
+    def __pos__(self):
+        pass
+    def __radd__(self):
+        pass
+    def __rmul__(self):
+        pass
+    def __rsub__(self):
+        pass
+    def __sub__(self):
+        pass
 
-	# need a way to represent these objects
-	# def __repr__(self):
-	# 	pass
+    # need a way to represent these objects
+    # def __repr__(self):
+    #   pass
 
-	# def __str__(self):
-	# 	pass
+    # def __str__(self):
+    #   pass

--- a/timeseries/test_lazy.py
+++ b/timeseries/test_lazy.py
@@ -4,39 +4,39 @@ from lazy import lazy, lazy_add, lazy_mul, LazyOperation
 
 @lazy
 def lazy_kwargs_mul(a, b, optional = 1):
-	"""
-		Test LazyOperation.eval() to verify functionality of self._kwargs.items()
+    """
+        Test LazyOperation.eval() to verify functionality of self._kwargs.items()
 
-		Returns
-		-------
-		a * b : the product of the two provided values
-		a * b * optional : the product of the three provided values, if a value is provided for optional
+        Returns
+        -------
+        a * b : the product of the two provided values
+        a * b * optional : the product of the three provided values, if a value is provided for optional
 
-		Notes
+        Notes
         -----
         PRE: if a value is provided for 'optional', the operation is altered
-	"""
-	if optional != 1:
-		return a * b * optional
-	return a * b
+    """
+    if optional != 1:
+        return a * b * optional
+    return a * b
 
 @lazy
 def lazy_kwargs_add(a, b, optional = 0):
-	"""
-		Test LazyOperation.eval() to verify functionality of self._kwargs.items()
+    """
+        Test LazyOperation.eval() to verify functionality of self._kwargs.items()
 
-		Returns
-		-------
-		a + b : the sum of the two provided values
-		a + b + optional : the sum of the three provided values, if a value is provided for optional
+        Returns
+        -------
+        a + b : the sum of the two provided values
+        a + b + optional : the sum of the three provided values, if a value is provided for optional
 
-		Notes
+        Notes
         -----
         PRE: if a value is provided for 'optional', the operation is altered
-	"""
-	if optional != 0:
-		return a + b + optional
-	return a + b
+    """
+    if optional != 0:
+        return a + b + optional
+    return a + b
 
 def test_isinstance():
     assert isinstance(lazy_add(1,1), LazyOperation) == True
@@ -58,8 +58,8 @@ def test_lazy_kwargs_add():
     assert lazy_kwargs_add(1, 5, optional = 50).eval() == 56
 
 def test_lazy_kwargs_mul():
-	assert lazy_kwargs_mul(5, 2).eval() == 10
-	assert lazy_kwargs_mul(1, 5, optional = 10).eval() == 50
+    assert lazy_kwargs_mul(5, 2).eval() == 10
+    assert lazy_kwargs_mul(1, 5, optional = 10).eval() == 50
 
 def test_lazy_interpolate():
     ts = TimeSeries([1,2,3,4,5], [0,5,10,15,20])

--- a/timeseries/test_simulatedtimeseries.py
+++ b/timeseries/test_simulatedtimeseries.py
@@ -3,13 +3,13 @@ from simulatedtimeseries import SimulatedTimeSeries
 
 def test_chunk_out_of_range():
 
-	with raises(StopIteration):
+    with raises(StopIteration):
 
-		chunk = 200
+        chunk = 200
 
-		test_range = range(chunk)
+        test_range = range(chunk)
 
-		times_gen = (t for t in [1,2,3])
-		values_gen = (v for v in [1,2,3])
-		ts = SimulatedTimeSeries(times_gen, values_gen)
-		produced = [(next(ts.times), next(ts.values)) for _ in range(chunk)]
+        times_gen = (t for t in [1,2,3])
+        values_gen = (v for v in [1,2,3])
+        ts = SimulatedTimeSeries(times_gen, values_gen)
+        produced = [(next(ts.times), next(ts.values)) for _ in range(chunk)]

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -7,7 +7,6 @@ import numpy as np
 from lazy import lazy
 from lazy import LazyOperation
 
-
 def test_sized_container_timeseries():
     """calls tests on *both* TimeSeries and ArrayTimeSeries"""
     for class_name in [TimeSeries,ArrayTimeSeries]:
@@ -40,14 +39,14 @@ def test_sized_container_timeseries():
         method_mul_int(class_name)
         method_mul_two_timeseries(class_name)
         method_ne(class_name)
+        method_produce()
 
 def test_time_series():
-    """Calles tests on time series class exclusively"""
+    """Calles tests on list-based timeseries class exclusively"""
     threes_fives(TimeSeries)
     verify_lazy_property_time_series(TimeSeries)
     verify_lazyfied_time_series_check_length(TimeSeries)
     # Code for these tests still needs to be abtracted to sizedcontainertimeseries interface
-    method_produce()
 
 ##############################################################################
 ## Unit Tests
@@ -178,7 +177,6 @@ def verify_lazyfied_time_series_check_length(class_name):
     thunk = check_length(class_name(range(0,4),range(1,5)), class_name(range(1,5),range(2,6)))
     assert thunk.eval()==True
 
-
 # should have made a fixture sorry!
 def method_getitem(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
@@ -201,6 +199,7 @@ def method_iter(class_name):
     assert cum_sum==18
 
 def method_values(class_name):
+    #N: Changed from np array to list
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     assert isinstance(threes.values(), list)
 
@@ -212,8 +211,9 @@ def method_itervalues(class_name):
     assert cum_sum==18
 
 def method_times(class_name):
+    #N: Changed from np array to list
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
-    assert isinstance(threes.times(), np.ndarray)
+    assert isinstance(threes.times(), list)
 
 def method_itertimes(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
@@ -241,9 +241,8 @@ def method_len(class_name):
 
 def method_pos(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
-    threespos = class_name(values=range(0, 10, 3),times=range(100,104))
     posthrees = +threes
-    assert posthrees == threespos
+    assert posthrees.values() == [0,3,6,9]
 
 def method_neg(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
@@ -252,10 +251,9 @@ def method_neg(class_name):
 
 def method_add_int(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
-    add_answer = class_name(values=[5,8,11,14],times=range(100,104))
     add_v1 = threes + 5
     add_v2 = 5 + threes
-    assert add_v1 == add_answer and add_v2 == add_answer
+    assert add_v1.values() == [5,8,11,14] and add_v2.values() == [5,8,11,14]
 
 def method_add_two_timeseries(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -6,6 +6,53 @@ import numpy as np
 from lazy import lazy
 from lazy import LazyOperation
 
+
+def test_sized_container_timeseries():
+    """calls tests on *both* TimeSeries and ArrayTimeSeries"""
+    for class_name in [TimeSeries,ArrayTimeSeries]:
+        non_iterable(class_name)
+        iterable(class_name)
+        incompatible_dimensions(class_name)
+        times_contains_repeats(class_name)
+        index_in_time_series(class_name)
+        index_not_in_time_series(class_name)
+        correct_length(class_name)
+        interpolate_ts(class_name)
+        method_getitem(class_name)
+        method_setitem(class_name)
+        method_iter(class_name)
+        method_contains(class_name)
+        method_values(class_name)
+        method_itervalues(class_name)
+        method_times(class_name)
+        method_itertimes(class_name)
+        method_items(class_name)
+        method_iteritems(class_name)
+        method_len(class_name)
+        method_eq(class_name)
+
+
+def test_time_series():
+    """Calles tests on time series class exclusively"""
+    threes_fives(TimeSeries)
+    verify_lazy_property_time_series(TimeSeries)
+    verify_lazyfied_time_series_check_length(TimeSeries)
+    # Code for these tests still needs to be abtracted to sizedcontainertimeseries interface
+    method_pos(TimeSeries)
+    method_neg(TimeSeries)
+    method_add_int(TimeSeries)
+    method_add_two_timeseries(TimeSeries)
+    method_sub_int(TimeSeries)
+    method_sub_two_timeseries(TimeSeries)
+    method_mul_int(TimeSeries)
+    method_mul_two_timeseries(TimeSeries)
+    method_ne(TimeSeries)
+    method_produce()
+
+##############################################################################
+## Unit Tests
+##############################################################################
+
 def threes_fives(class_name):
     """
     Check with fizbuzz data
@@ -128,72 +175,9 @@ def verify_lazyfied_time_series_check_length(class_name):
     @lazy
     def check_length(a,b):
         return len(a)==len(b)
-    thunk = check_length(TimeSeries(range(0,4),range(1,5)), TimeSeries(range(1,5),range(2,6)))
+    thunk = check_length(class_name(range(0,4),range(1,5)), class_name(range(1,5),range(2,6)))
     assert thunk.eval()==True
 
-def test_time_series():
-    """Calles tests defined above on time series class"""
-    threes_fives(TimeSeries)
-    non_iterable(TimeSeries)
-    iterable(TimeSeries)
-    incompatible_dimensions(TimeSeries)
-    times_contains_repeats(TimeSeries)
-    index_in_time_series(TimeSeries) # (Fixed) get item changed! gets value based on index rather than time now
-    index_not_in_time_series(TimeSeries) # (Fixed) get item changed! gets value based on index rather than time now
-    correct_length(TimeSeries)
-    interpolate_ts(TimeSeries)
-    verify_lazy_property_time_series(TimeSeries)
-    verify_lazyfied_time_series_check_length(TimeSeries)
-
-def test_array_time_series():
-    """Calles tests defined above on array time series class"""
-    # threes_fives(ArrayTimeSeries)
-    method_eq(ArrayTimeSeries)
-    non_iterable(ArrayTimeSeries)
-    iterable(ArrayTimeSeries)
-    times_contains_repeats(ArrayTimeSeries)
-    correct_length(ArrayTimeSeries)
-    incompatible_dimensions(ArrayTimeSeries)
-    index_in_time_series(ArrayTimeSeries) # (Fixed) get item changed! gets value based on index rather than time now
-    index_not_in_time_series(ArrayTimeSeries) # (Fixed) get item changed! gets value based on index rather than time now
-
-
-    # J: disabled this since __getitem__ and __setitem__
-    # now inherited from base class
-    #update_get_array_time_series_by_index(ArrayTimeSeries)
-
-    interpolate_ts(ArrayTimeSeries)
-    incompatible_dimensions(ArrayTimeSeries)
-    # These should work but don't -- need to look into further
-    #index_not_in_time_series(ArrayTimeSeries)
-    #correct_length(ArrayTimeSeries)
-    #times_contains_repeats(ArrayTimeSeries)
-
-# The following tests are interface checks - easy examples that don't handle edge cases
-
-def test_interface():
-    method_getitem(TimeSeries)
-    method_setitem(TimeSeries)
-    method_contains(TimeSeries)
-    method_iter(TimeSeries)
-    method_values(TimeSeries)
-    method_itervalues(TimeSeries)
-    method_times(TimeSeries)
-    method_itertimes(TimeSeries)
-    method_items(TimeSeries)
-    method_iteritems(TimeSeries)
-    method_len(TimeSeries)
-    method_pos(TimeSeries)
-    method_neg(TimeSeries)
-    method_add_int(TimeSeries)
-    method_add_two_timeseries(TimeSeries)
-    method_sub_int(TimeSeries)
-    method_sub_two_timeseries(TimeSeries)
-    method_mul_int(TimeSeries)
-    method_mul_two_timeseries(TimeSeries)
-    method_eq(TimeSeries)
-    method_ne(TimeSeries)
-    method_produce()
 
 # should have made a fixture sorry!
 def method_getitem(class_name):
@@ -206,7 +190,7 @@ def method_setitem(class_name):
     assert threes[0] == 3
 
 def method_contains(class_name):
-    x = class_name([5,6])
+    x = class_name(values=[5,6],times=[1,2])
     assert 5 in x
 
 def method_iter(class_name):

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -157,7 +157,7 @@ def test_array_time_series():
     index_in_time_series(ArrayTimeSeries) # (Fixed) get item changed! gets value based on index rather than time now
     index_not_in_time_series(ArrayTimeSeries) # (Fixed) get item changed! gets value based on index rather than time now
 
-    
+
     # J: disabled this since __getitem__ and __setitem__
     # now inherited from base class
     #update_get_array_time_series_by_index(ArrayTimeSeries)

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -32,6 +32,14 @@ def test_sized_container_timeseries():
         method_len(class_name)
         method_eq(class_name)
         method_pos(class_name)
+        method_neg(class_name)
+        method_add_int(class_name)
+        method_add_two_timeseries(class_name)
+        method_sub_int(class_name)
+        method_sub_two_timeseries(class_name)
+        method_mul_int(class_name)
+        method_mul_two_timeseries(class_name)
+        method_ne(class_name)
 
 def test_time_series():
     """Calles tests on time series class exclusively"""
@@ -39,15 +47,6 @@ def test_time_series():
     verify_lazy_property_time_series(TimeSeries)
     verify_lazyfied_time_series_check_length(TimeSeries)
     # Code for these tests still needs to be abtracted to sizedcontainertimeseries interface
-    method_pos(TimeSeries)
-    method_neg(TimeSeries)
-    method_add_int(TimeSeries)
-    method_add_two_timeseries(TimeSeries)
-    method_sub_int(TimeSeries)
-    method_sub_two_timeseries(TimeSeries)
-    method_mul_int(TimeSeries)
-    method_mul_two_timeseries(TimeSeries)
-    method_ne(TimeSeries)
     method_produce()
 
 ##############################################################################
@@ -203,7 +202,7 @@ def method_iter(class_name):
 
 def method_values(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
-    assert isinstance(threes.values(), np.ndarray)
+    assert isinstance(threes.values(), list)
 
 def method_itervalues(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
@@ -243,53 +242,53 @@ def method_len(class_name):
 def method_pos(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     threespos = class_name(values=range(0, 10, 3),times=range(100,104))
-    #print("from test",type(threespos),threespos)
     posthrees = +threes
     assert posthrees == threespos
 
 def method_neg(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     negthrees = -threes
-    assert negthrees._values==[0,-3,-6,-9]
+    assert negthrees.values()==[0,-3,-6,-9]
 
 def method_add_int(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
+    add_answer = class_name(values=[5,8,11,14],times=range(100,104))
     add_v1 = threes + 5
     add_v2 = 5 + threes
-    assert add_v1._values==[5,8,11,14] and add_v2._values==[5,8,11,14]
+    assert add_v1 == add_answer and add_v2 == add_answer
 
 def method_add_two_timeseries(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     fives = class_name(values=range(0, 16, 5),times=range(100,104))
     add_v1 = threes+fives
     add_v2 = fives+threes
-    assert add_v1._values==[0,8,16,24] and add_v2._values==[0,8,16,24]
+    assert add_v1.values()==[0,8,16,24] and add_v2.values()==[0,8,16,24]
 
 def method_sub_int(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     sub_v1 = threes - 5
     sub_v2 = -(5 - threes)
-    assert sub_v1._values==[-5,-2,1,4] and sub_v2._values==[-5,-2,1,4]
+    assert sub_v1.values()==[-5,-2,1,4] and sub_v2.values()==[-5,-2,1,4]
 
 def method_sub_two_timeseries(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     fives = class_name(values=range(0, 16, 5),times=range(100,104))
     sub_v1 = threes-fives
     sub_v2 = -(fives-threes)
-    assert sub_v1._values==[0,-2,-4,-6] and sub_v2._values==[0,-2,-4,-6]
+    assert sub_v1.values()==[0,-2,-4,-6] and sub_v2.values()==[0,-2,-4,-6]
 
 def method_mul_int(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     mul_v1 = threes * 5
     mul_v2 = 5 * threes
-    assert mul_v1._values==[0,15,30,45] and mul_v2._values==[0,15,30,45]
+    assert mul_v1.values()==[0,15,30,45] and mul_v2.values()==[0,15,30,45]
 
 def method_mul_two_timeseries(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
     fives = class_name(values=range(0, 16, 5),times=range(100,104))
     mul_v1 = threes*fives
     mul_v2 = fives*threes
-    assert mul_v1._values==[0,15,60,135] and mul_v2._values==[0,15,60,135]
+    assert mul_v1.values()==[0,15,60,135] and mul_v2.values()==[0,15,60,135]
 
 def method_eq(class_name):
     eq_v1 = class_name(values=range(0, 10, 3),times=range(100,104))

--- a/timeseries/test_timeseries.py
+++ b/timeseries/test_timeseries.py
@@ -1,4 +1,5 @@
 from pytest import raises
+import pytest
 from timeseries import TimeSeries
 from arraytimeseries import ArrayTimeSeries
 from simulatedtimeseries import SimulatedTimeSeries
@@ -30,7 +31,7 @@ def test_sized_container_timeseries():
         method_iteritems(class_name)
         method_len(class_name)
         method_eq(class_name)
-
+        method_pos(class_name)
 
 def test_time_series():
     """Calles tests on time series class exclusively"""
@@ -241,8 +242,10 @@ def method_len(class_name):
 
 def method_pos(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))
+    threespos = class_name(values=range(0, 10, 3),times=range(100,104))
+    #print("from test",type(threespos),threespos)
     posthrees = +threes
-    assert posthrees._values==[0,3,6,9]
+    assert posthrees == threespos
 
 def method_neg(class_name):
     threes = class_name(values=range(0, 10, 3),times=range(100,104))

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -111,19 +111,15 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
         try:
             if isinstance(rhs, numbers.Real):
                 # R: may be worth testing time domains are preserved correctly
-                return self.__class__((a + rhs for a in self), self._times)
+                return self.__class__(values=(a + rhs for a in self), times=self._times)
             else:
                 self._check_length_helper(self, rhs)
                 # R: test me. should fail when the time domains are non congruent
                 self._check_time_domains_helper(self, rhs)
                 pairs = zip(self._values, rhs)
-                return self.__class__((a + b for a, b in pairs), self._times)
+                return self.__class__(values=(a + b for a, b in pairs), times=self._times)
         except TypeError:
             raise NotImplemented # R: test me. should fail when we try to add a numpy array or list
-
-
-    def __radd__(self, other): # other + self delegates to self.__add__
-        return self + other
 
     def __sub__(self, rhs):
         try:
@@ -137,8 +133,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
         except TypeError:
             raise NotImplemented
 
-    def __rsub__(self, other):
-        return -(self - other)
 
     def __mul__(self, rhs):
         try:
@@ -152,8 +146,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
         except TypeError:
             raise NotImplemented
 
-    def __rmul__(self, other):
-        return self * other
 
     def __eq__(self, rhs):
         self._check_length_helper(self, rhs)
@@ -163,9 +155,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
             return self._values==rhs._values
         except TypeError:
             raise NotImplemented
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     @lazy
     def identity(self):

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -164,54 +164,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def interpolate(self,ts_to_interpolate):
-        """
-        Returns new TimeSeries instance with piecewise-linear-interpolated values
-        for submitted time-times.If called times are outside of the domain of the existing
-        Time Series, the minimum or maximum values are returned.
-
-        Parameters
-        ----------
-        self: TimeSeries instance
-        ts_to_interpolate: list or other sequence of times to be interpolated
-
-        """
-        def binary_search(times, t):
-            """ Returns surrounding time indexes for value that is to be interpolated"""
-            min = 0
-            max = len(times) - 1
-            while True:
-                if max < min:
-                    return (max,min)
-                m = (min + max) // 2
-                if times[m] < t:
-                    min = m + 1
-                elif times[m] > t:
-                    max = m - 1
-                else: #Should never hit this case in current implementation
-                    return (min,max)
-
-        def interpolate_val(times,values,t):
-            """Returns interpolated value for given time"""
-
-            if t in times:          #time already exits in ts -- return it
-                return values[times.index(t)]
-
-            elif t >= times[-1]:    #time is above the domain of the existing values -- return max time value
-                return values[-1]
-
-            elif t <= times[0]:     #time is below the domain of the existing values -- return min time value
-                return values[0]
-
-            else:                   #time is between two existing points -- interpolate it
-                low,high = binary_search(times, t)
-                slope = (float(values[high]) - values[low])/(times[high] - times[low])
-                c = values[low]
-                interpolated_val = (t-times[low])*slope + c
-                return interpolated_val
-
-        interpolated_ts = [interpolate_val(self._times,self._values,t) for t in ts_to_interpolate]
-        return self.__class__(values=interpolated_ts,times=ts_to_interpolate)
 
     @lazy
     def identity(self):

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -91,9 +91,9 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
 
     # J: Also abstracted this to parent class...
     # def __contains__(self, needle):
-        
-    #     # J this also works for  
-    #     # R: leverages self._values is a list. 
+
+    #     # J this also works for
+    #     # R: leverages self._values is a list.
     #     # Will have to change when we relax this.
     #     return needle in self._values
 

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -98,40 +98,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
     #     return needle in self._values
 
 
-    def __neg__(self):
-        return TimeSeries((-x for x in self._values), self._times)
-
-    def __pos__(self):
-        return TimeSeries((x for x in self._values), self._times)
-
-    def __add__(self, rhs):
-        try:
-            if isinstance(rhs, numbers.Real):
-                # R: may be worth testing time domains are preserved correctly
-                return TimeSeries((a + rhs for a in self), self._times)
-            else:
-                self._check_length_helper(self, rhs)
-                # R: test me. should fail when the time domains are non congruent
-                self._check_time_domains_helper(self, rhs)
-                pairs = zip(self._values, rhs)
-                return TimeSeries((a + b for a, b in pairs), self._times)
-        except TypeError:
-            raise NotImplemented # R: test me. should fail when we try to add a numpy array or list
-
-    def __radd__(self, other): # other + self delegates to self.__add__
-        return self + other
-
-    def __sub__(self, rhs):
-        try:
-            if isinstance(rhs, numbers.Real):
-                return TimeSeries((a - rhs for a in self), self._times)
-            else:
-                self._check_length_helper(self, rhs)
-                self._check_time_domains_helper(self, rhs)
-                pairs = zip(self._values, rhs)
-                return TimeSeries((a - b for a, b in pairs), self._times)
-        except TypeError:
-            raise NotImplemented
 
     # J: should this not be (self - other)?
     def __rsub__(self, other):
@@ -163,7 +129,6 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
 
     @lazy
     def identity(self):

--- a/timeseries/timeseries.py
+++ b/timeseries/timeseries.py
@@ -100,6 +100,43 @@ class TimeSeries(SizedContainerTimeSeriesInterface):
 
 
     # J: should this not be (self - other)?
+
+    def __neg__(self):
+        return self.__class__((-x for x in self._values), self._times)
+
+    def __pos__(self):
+        return self.__class__((x for x in self._values), self._times)
+
+    def __add__(self, rhs):
+        try:
+            if isinstance(rhs, numbers.Real):
+                # R: may be worth testing time domains are preserved correctly
+                return self.__class__((a + rhs for a in self), self._times)
+            else:
+                self._check_length_helper(self, rhs)
+                # R: test me. should fail when the time domains are non congruent
+                self._check_time_domains_helper(self, rhs)
+                pairs = zip(self._values, rhs)
+                return self.__class__((a + b for a, b in pairs), self._times)
+        except TypeError:
+            raise NotImplemented # R: test me. should fail when we try to add a numpy array or list
+
+
+    def __radd__(self, other): # other + self delegates to self.__add__
+        return self + other
+
+    def __sub__(self, rhs):
+        try:
+            if isinstance(rhs, numbers.Real):
+                return self.__class__((a - rhs for a in self), self._times)
+            else:
+                self._check_length_helper(self, rhs)
+                self._check_time_domains_helper(self, rhs)
+                pairs = zip(self._values, rhs)
+                return self.__class__((a - b for a, b in pairs), self._times)
+        except TypeError:
+            raise NotImplemented
+
     def __rsub__(self, other):
         return -(self - other)
 

--- a/timeseries/timeseriesinterface.py
+++ b/timeseries/timeseriesinterface.py
@@ -1,90 +1,90 @@
-# Implements the TimeSeriesInterface ABC 
+# Implements the TimeSeriesInterface ABC
 
 import abc
 
 class TimeSeriesInterface(abc.ABC):
-	"""Interface for TimeSeries"""
+    """Interface for TimeSeries"""
 
-	##############################################################################
-	## GLOBAL CONSTANT FOR ALL TIMESERIES
-	##############################################################################
-	MAX_LENGTH = 10
+    ##############################################################################
+    ## GLOBAL CONSTANT FOR ALL TIMESERIES
+    ##############################################################################
+    MAX_LENGTH = 10
 
-	##############################################################################
-	## ABSTRACT METHODS TO BE IMPLEMENTED BY ALL TIMESERIES OF FIXED LENGTH
-	##############################################################################
+    ##############################################################################
+    ## ABSTRACT METHODS TO BE IMPLEMENTED BY ALL TIMESERIES OF FIXED LENGTH
+    ##############################################################################
 
-	@abc.abstractmethod
-	def __iter__(self):
-		"""
-		Description
-		-----------
-		Fixed size or not, each TimeSeries needs to support iteration.
-		"""
-		pass
+    @abc.abstractmethod
+    def __iter__(self):
+        """
+        Description
+        -----------
+        Fixed size or not, each TimeSeries needs to support iteration.
+        """
+        pass
 
-	@abc.abstractmethod
-	def __neg__(self):
-		"""
-		Description
-		-----------
-		All TimeSeries, fixed or not, should support unary `-` operator
-		"""
-		pass
-	
-	@abc.abstractmethod
-	def __pos__(self):
-		"""
-		Description
-		-----------
-		Obviously all TimeSeries need to suppport opposite of __neg__ as well.
-		"""
-		pass
-	
+    @abc.abstractmethod
+    def __neg__(self):
+        """
+        Description
+        -----------
+        All TimeSeries, fixed or not, should support unary `-` operator
+        """
+        pass
 
-	# J: I'm assuming these methods can be implemented lazily,
-	# so including them at the top of the hierarchy...
+    @abc.abstractmethod
+    def __pos__(self):
+        """
+        Description
+        -----------
+        Obviously all TimeSeries need to suppport opposite of __neg__ as well.
+        """
+        pass
 
-	@abc.abstractmethod
-	def __add__(self, rhs):
-		"""
-		Description
-		-----------
-		All TimeSeries should support adding a constant to each element
-		"""
-		pass
-	
-	@abc.abstractmethod
-	def __radd__(self, other):
-		"""
-		Description
-		-----------
-		All TimeSeries should support adding a constant to each element
-		"""
-		pass
 
-	@abc.abstractmethod
-	def __sub__(self, rhs):
-		"""
-		Description
-		-----------
-		All TimeSeries should support subtracting a constant from each element
-		"""
-		pass
-	
-	@abc.abstractmethod
-	def __rsub__(self, other):
-		pass
-	
-	@abc.abstractmethod
-	def __mul__(self, rhs):
-		"""
-		Description
-		-----------
-		All TimeSeries must support multiplication by a constant
-		"""
-		pass
-	
-	@abc.abstractmethod
-	def __rmul__(self):
-		pass
+    # J: I'm assuming these methods can be implemented lazily,
+    # so including them at the top of the hierarchy...
+
+    @abc.abstractmethod
+    def __add__(self, rhs):
+        """
+        Description
+        -----------
+        All TimeSeries should support adding a constant to each element
+        """
+        pass
+
+    @abc.abstractmethod
+    def __radd__(self, other):
+        """
+        Description
+        -----------
+        All TimeSeries should support adding a constant to each element
+        """
+        pass
+
+    @abc.abstractmethod
+    def __sub__(self, rhs):
+        """
+        Description
+        -----------
+        All TimeSeries should support subtracting a constant from each element
+        """
+        pass
+
+    @abc.abstractmethod
+    def __rsub__(self, other):
+        pass
+
+    @abc.abstractmethod
+    def __mul__(self, rhs):
+        """
+        Description
+        -----------
+        All TimeSeries must support multiplication by a constant
+        """
+        pass
+
+    @abc.abstractmethod
+    def __rmul__(self):
+        pass


### PR DESCRIPTION
Changes: 
- Standardized all files to use space-indentation
- abstracted interpolate to sizedcontainer interface
- abstracted  _radd,_rsub, _rul to sizedcontainer interface (these seem like they are always going to be the same) 
- implemented _neg, _pos, _add, _mul, _sub in array time series 
- changed  sizedcontainer .values() and times() to explicitly cast to lists. This makes using unit tests across both classes much easier. But let me know if there was a reason it was previously casting to np.array and we can make a separate method for the list representation. 
